### PR TITLE
fix: iOS crashes caused by "eventV3" function, if the "params" is null.

### DIFF
--- a/ios/Classes/RangersApplogFlutterPlugin.m
+++ b/ios/Classes/RangersApplogFlutterPlugin.m
@@ -98,7 +98,7 @@ static inline id setNSNullToNil(id value, Class target){
     else if ([methodName isEqualToString:@"onEventV3"]) {
         // NSLog(@"%@", call.arguments);
         NSString *event = setNSNullToNil([arguments valueForKey:@"event"], [NSString class]);
-        NSDictionary *param = [arguments valueForKey:@"param"];
+        NSDictionary *param = setNSNullToNil([arguments valueForKey:@"param"], [NSDictionary class]);
         BOOL ret = [[BDAutoTrack sharedTrack] eventV3:event params:param];
         result(nil);
     }


### PR DESCRIPTION
If call `RangersApplogFlutterPlugin.onEventV3(event, params)` with null params, the parsed result of param on iOS will be "NSNull".

<img width="706" alt="image" src="https://github.com/user-attachments/assets/d4493323-b5ff-4ff7-96e1-e260f6ddcee4">

And then `[[BDAutoTrack sharedTrack] eventV3:event params:{{NSNull instance}}]` will cause crash.

This pr can be related with the issue #10 .